### PR TITLE
feat(popup-modal): add custom popup modal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Webflow Optimize Snippets
-Code snippets and examples for Webflow Optimize
+These examples are intended to help spark ideas and speed up implementation. They're not official product features, but they can be used for inspiration as you code your own optimizations. Feel free to adapt these examples to your own needs!
+
+## Examples
+* [Custom modal utility (delay or exit intent trigger)](/popup-modal/)

--- a/popup-modal/README.md
+++ b/popup-modal/README.md
@@ -1,0 +1,58 @@
+# Popup Modal Utility for Webflow Optimize
+
+This utility adds a fully customizable popup modal to your site using Webflow Optimize. It supports two trigger types – time delay or exit intent – and allows for flexible content and responsive two-column layouts.
+
+It is designed to be accessible and easy to adapt.
+
+---
+
+## 🛠 Setup
+
+1. Add `popup-modal-utility.js` to your **Global JavaScript** in Webflow Optimize (Account Settings).
+2. In your variation, call `popupModal()` with your desired content and behavior.
+
+---
+
+## ⚙️ Options
+
+| Option                | Type     | Description                                                                 |
+|------------------------|----------|-----------------------------------------------------------------------------|
+| `leftHtml`             | `string` | Optional. HTML content for the left side (e.g., image or illustration).     |
+| `rightHtml`            | `string` | Optional. HTML content for the right side (e.g., headings, text, CTA).      |
+| `trigger`              | `string` | `'delay'` or `'exit-intent'`. Controls when the modal appears.              |
+| `delayMs`              | `number` | Milliseconds to wait before showing (only if `trigger: 'delay'`). Default: 5000. |
+| `exitIntentOptions`    | `object` | Optional. Configures behavior of `exit-intent` trigger.                     |
+| `customClassName`      | `string` | Optional. Adds a custom class to the modal wrapper for styling.             |
+
+---
+
+### 🧠 `exitIntentOptions`
+
+Used only when `trigger` is set to `'exit-intent'`.
+
+| Option         | Type     | Description                                                                 |
+|----------------|----------|-----------------------------------------------------------------------------|
+| `idleDelay`    | `number` | Time (ms) after page load before monitoring for exit behavior. Default: 1000 |
+| `triggerEdge`  | `number` | Distance from top of screen (in pixels) that counts as exit intent. Default: 50 |
+
+Example: `triggerEdge: 30` means the modal will appear if the user’s mouse moves within 30 pixels of the top of the viewport.
+
+---
+
+## 🧪 Example usage
+
+```js
+window.wf_optimize.utils.popupModal({
+  leftHtml: '<img src="https://placehold.co/400x300?text=Popup+Image" alt="Product screenshot" />',
+  rightHtml: `
+    <h2 id="modal-heading">Ready to get started?</h2>
+    <p>Let us help you choose the right plan.</p>
+    <button onclick="alert('CTA clicked!')">Book a demo</button>
+  `,
+  trigger: 'exit-intent',
+  exitIntentOptions: {
+    idleDelay: 1000,
+    triggerEdge: 50
+  },
+  customClassName: 'custom-popup'
+});

--- a/popup-modal/popup-modal-utility.js
+++ b/popup-modal/popup-modal-utility.js
@@ -1,0 +1,185 @@
+(() => {
+  window.wf_optimize = window.wf_optimize || {};
+  window.wf_optimize.utils = window.wf_optimize.utils || {};
+
+  window.wf_optimize.utils.popupModal = function ({
+    leftHtml = "",
+    rightHtml = "",
+    trigger = "delay",
+    delayMs = 5000,
+    exitIntentOptions = { idleDelay: 1000, triggerEdge: 50 },
+    customClassName = "",
+  } = {}) {
+    let previousActiveElement;
+
+    const trapFocus = (modal) => {
+      const focusable = modal.querySelectorAll(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      modal.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          closeModal();
+        } else if (e.key === "Tab") {
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    };
+
+    const closeModal = () => {
+      const backdrop = document.querySelector(".wfoptimize-modal-backdrop");
+      if (backdrop) {
+        document.body.removeChild(backdrop);
+        document.body.style.overflow = "";
+        if (previousActiveElement) previousActiveElement.focus();
+      }
+    };
+
+    const createModal = () => {
+      if (!document.getElementById("wfoptimize-custom-modal-style")) {
+        const style = document.createElement("style");
+        style.id = "wfoptimize-custom-modal-style";
+        style.textContent = `
+          .wfoptimize-modal-backdrop {
+            position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+            display: flex; justify-content: center; align-items: center;
+            z-index: 9999;
+          }
+          .wfoptimize-modal {
+            display: flex;
+            flex-direction: column;
+            background: white;
+            border-radius: 8px;
+            max-width: 800px;
+            width: 95%;
+            overflow: hidden;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.2);
+            font-family: sans-serif;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            position: relative;
+          }
+          .wfoptimize-modal.ready {
+            opacity: 1;
+          }
+          .wfoptimize-modal.two-column {
+            flex-direction: row;
+          }
+          .wfoptimize-modal .modal-left,
+          .wfoptimize-modal .modal-right {
+            padding: 32px;
+            box-sizing: border-box;
+          }
+          .wfoptimize-modal .modal-left {
+            flex: 1 1 50%;
+            background: #f9f9f9;
+          }
+          .wfoptimize-modal .modal-right {
+            flex: 1 1 50%;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+          }
+          .wfoptimize-modal .modal-right h2 {
+            margin-top: 0;
+          }
+          .wfoptimize-modal-close {
+            position: absolute;
+            top: 12px;
+            right: 12px;
+            background: none;
+            border: none;
+            font-size: 1.5rem;
+            cursor: pointer;
+            z-index: 10;
+          }
+          @media (max-width: 768px) {
+            .wfoptimize-modal.two-column {
+              flex-direction: column;
+            }
+          }
+        `;
+        document.head.appendChild(style);
+      }
+
+      previousActiveElement = document.activeElement;
+
+      const backdrop = document.createElement("div");
+      backdrop.className = "wfoptimize-modal-backdrop";
+      backdrop.addEventListener("click", (e) => {
+        if (e.target === backdrop) closeModal();
+      });
+
+      const modal = document.createElement("div");
+      modal.className = `wfoptimize-modal ${customClassName}`.trim();
+      modal.setAttribute("role", "dialog");
+      modal.setAttribute("aria-modal", "true");
+      modal.setAttribute("aria-labelledby", "modal-heading");
+      modal.setAttribute("tabindex", "-1");
+
+      const hasLeft = Boolean(leftHtml?.trim());
+      const hasRight = Boolean(rightHtml?.trim());
+      if (hasLeft && hasRight) modal.classList.add("two-column");
+
+      const closeBtn = document.createElement("button");
+      closeBtn.className = "wfoptimize-modal-close";
+      closeBtn.setAttribute("aria-label", "Close modal");
+      closeBtn.innerHTML = "&times;";
+      closeBtn.addEventListener("click", closeModal);
+
+      if (hasLeft) {
+        const left = document.createElement("div");
+        left.className = "modal-left";
+        left.innerHTML = leftHtml;
+        modal.appendChild(left);
+      }
+
+      if (hasRight) {
+        const right = document.createElement("div");
+        right.className = "modal-right";
+        right.innerHTML = rightHtml;
+        modal.appendChild(right);
+      }
+
+      modal.appendChild(closeBtn);
+      backdrop.appendChild(modal);
+      document.body.appendChild(backdrop);
+      document.body.style.overflow = "hidden";
+
+      setTimeout(() => {
+        modal.classList.add("ready");
+        modal.focus();
+        trapFocus(modal);
+      }, 50);
+    };
+
+    const triggerModal = () => {
+      if (document.querySelector(".wfoptimize-modal-backdrop")) return;
+      createModal();
+    };
+
+    if (trigger === "exit-intent") {
+      const { idleDelay = 1000, triggerEdge = 50 } = exitIntentOptions || {};
+      const onMouseMove = (e) => {
+        if (e.clientY <= triggerEdge) {
+          window.removeEventListener("mousemove", onMouseMove);
+          triggerModal();
+        }
+      };
+      setTimeout(
+        () => window.addEventListener("mousemove", onMouseMove),
+        idleDelay
+      );
+    } else {
+      setTimeout(triggerModal, delayMs);
+    }
+  };
+})();

--- a/popup-modal/sample-variation-code.js
+++ b/popup-modal/sample-variation-code.js
@@ -1,0 +1,16 @@
+window.wf_optimize.utils.popupModal({
+  leftHtml: `
+    <img src="https://placehold.co/400x300?text=Popup+Image" alt="Example modal image" />
+  `,
+  rightHtml: `
+    <h2 id="modal-heading">Need help choosing?</h2>
+    <p>Let us help you find the right solution for your team.</p>
+    <button class="modal-cta" onclick="alert('CTA clicked!')">Get a Recommendation</button>
+  `,
+  trigger: "exit-intent",
+  exitIntentOptions: {
+    idleDelay: 1000,
+    triggerEdge: 50,
+  },
+  customClassName: "custom-tour-modal",
+});


### PR DESCRIPTION
This PR adds an example of a self-contained popup modal utility.

The utility supports:
- Triggering via **time delay** or **customizable exit intent**
- Flexible layout using `leftHtml` and `rightHtml`
- **Responsive two-column layout** that stacks on mobile
- **Accessibility best practices**

**Included in this PR:**
- `popup-modal-utility.js` (global JS utility)
- `sample-variation-code.js` (example usage in Optimize variation)
- `README.md` (setup instructions, options)

This snippet is intended for general use across customers and replaces the need for ad hoc custom builds.